### PR TITLE
Fix generating stride schematics in Camel case ends up generated in Title case

### DIFF
--- a/src/generate/index.ts
+++ b/src/generate/index.ts
@@ -18,7 +18,7 @@ const strideGenerate = (program: Command) =>
     .option('--no-page', 'prevent module schematics to generate pages')
     .option('--as <alias>', 'generate schematics with aliases')
     .action((schematic: Schematic, name: string, options: GenerateOptions) =>
-      generateFunction(schematic, name.toLowerCase(), options)
+      generateFunction(schematic, name, options)
     )
 
 export default strideGenerate


### PR DESCRIPTION
Remove forced lowercase in src/generate/index.ts while calling the "generateFunction" function.